### PR TITLE
Fix drag-and-drop

### DIFF
--- a/src/coffee/views/drop_zone.coffee
+++ b/src/coffee/views/drop_zone.coffee
@@ -34,7 +34,7 @@ class JiraStoryTime.Views.DropZone extends JiraStoryTime.Utils.Observer
   handleDragEnter: (e) =>
     @el.addClass "over"
 
-  handleDragOver: (e) =>
+  handleDragOver: (e) ->
     e.preventDefault()
 
   handleDragLeave: (e) =>

--- a/src/coffee/views/drop_zone.coffee
+++ b/src/coffee/views/drop_zone.coffee
@@ -9,6 +9,7 @@ class JiraStoryTime.Views.DropZone extends JiraStoryTime.Utils.Observer
 
     @el.on "dragstart", @handleDragStart
     @el.on "dragenter", @handleDragEnter
+    @el.find(".story_board_row_drop_mask").on "dragover", @handleDragOver
     @el.find(".story_board_row_drop_mask").on "dragleave", @handleDragLeave
     @el.find(".story_board_row_drop_mask").on "drop", @handleDrop
 
@@ -32,6 +33,9 @@ class JiraStoryTime.Views.DropZone extends JiraStoryTime.Utils.Observer
 
   handleDragEnter: (e) =>
     @el.addClass "over"
+
+  handleDragOver: (e) =>
+    e.preventDefault()
 
   handleDragLeave: (e) =>
     @el.removeClass "over"


### PR DESCRIPTION
Dropping wasn't working before because the `dragover` event wasn't being prevented, and so the columns weren't considered valid drop targets. Now drag-and-drop works perfectly.