### PR TITLE
Fix Story Expanding!

### DIFF
--- a/src/coffee/views/drop_zone.coffee
+++ b/src/coffee/views/drop_zone.coffee
@@ -19,7 +19,7 @@ class JiraStoryTime.Views.DropZone extends JiraStoryTime.Utils.Observer
   onObservedChange: (change) =>
     change.removed.forEach (view) =>
       if @el.has(view.el).length > 0
-        view.el.remove()
+        view.el.detach()
     if change.addedCount > 0
       for i in [0..change.addedCount-1] by 1
         insertBeforeElement = @el.find('.story-item')[i + change.index]


### PR DESCRIPTION
Wahahaha!

Turns out jquery cleans up events on remove()--need to use detach() if we want to preserve events